### PR TITLE
Add live league table feature with real-time standings

### DIFF
--- a/api/get-live-standings.js
+++ b/api/get-live-standings.js
@@ -1,0 +1,151 @@
+// api/get-live-standings.js
+const LEAGUE_API_URL = 'https://fantasy.premierleague.com/api/leagues-classic/';
+const TEAM_API_URL = 'https://fantasy.premierleague.com/api/entry/';
+const BOOTSTRAP_URL = 'https://fantasy.premierleague.com/api/bootstrap-static/';
+
+// Helper function to introduce a delay
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+// Helper function to fetch with retry logic
+const fetchWithRetry = async (url, retries = 3, delay = 1000) => {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return response;
+      }
+      if (attempt < retries) {
+        console.warn(`  Attempt ${attempt} failed for ${url}. Status: ${response.status}. Retrying in ${delay}ms...`);
+        await sleep(delay);
+      }
+    } catch (error) {
+      if (attempt < retries) {
+        console.warn(`  Attempt ${attempt} failed for ${url}. Error: ${error.message}. Retrying in ${delay}ms...`);
+        await sleep(delay);
+      } else {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`Failed to fetch ${url} after ${retries} attempts.`);
+};
+
+// Vercel serverless function entry point
+module.exports = async (req, res) => {
+  console.log('--- FPL Live Standings Request ---');
+  try {
+    const leagueId = req.query.leagueId;
+    console.log(`Received request for League ID: ${leagueId}`);
+
+    if (!leagueId) {
+      console.error('Error: leagueId parameter is missing.');
+      return res.status(400).json({ error: 'Please provide a leagueId parameter.' });
+    }
+
+    // Step 1: Get current gameweek information
+    console.log('Step 1: Fetching current gameweek...');
+    const bootstrapResponse = await fetchWithRetry(BOOTSTRAP_URL);
+    const bootstrapData = await bootstrapResponse.json();
+    const currentGameweek = bootstrapData.events.find(event => event.is_current).id;
+    console.log(`Current Gameweek is: ${currentGameweek}`);
+
+    // Step 2: Fetch league standings to get managers and their last week positions
+    console.log(`Step 2: Fetching league standings for league ID: ${leagueId}`);
+    const leagueResponse = await fetchWithRetry(`${LEAGUE_API_URL}${leagueId}/standings/`);
+    const leagueData = await leagueResponse.json();
+
+    if (leagueData.detail === 'Not found.') {
+      console.error('Error: League not found.');
+      return res.status(404).json({ error: 'League not found. Please check the League ID.' });
+    }
+
+    // Step 3: Get live data for each manager
+    console.log('Step 3: Fetching live data for each manager...');
+    const liveStandings = [];
+
+    for (const manager of leagueData.standings.results) {
+      const managerId = manager.entry;
+      console.log(`Processing manager: ${manager.player_name} (ID: ${managerId})`);
+
+      try {
+        // Get current gameweek live data
+        const currentGwResponse = await fetchWithRetry(`${TEAM_API_URL}${managerId}/event/${currentGameweek}/picks/`);
+        const currentGwData = await currentGwResponse.json();
+
+        // Get previous gameweek data for position comparison
+        let previousGwPoints = 0;
+        if (currentGameweek > 1) {
+          try {
+            const previousGwResponse = await fetchWithRetry(`${TEAM_API_URL}${managerId}/event/${currentGameweek - 1}/picks/`);
+            const previousGwData = await previousGwResponse.json();
+            if (previousGwData.entry_history) {
+              previousGwPoints = previousGwData.entry_history.total_points;
+            }
+          } catch (error) {
+            console.warn(`Could not fetch previous gameweek data for manager ${managerId}`);
+          }
+        }
+
+        // Calculate live points and this week's points
+        const currentGwPoints = currentGwData.entry_history ? currentGwData.entry_history.points : 0;
+        const livePoints = currentGwData.entry_history ? currentGwData.entry_history.total_points : manager.total;
+
+        // Find last week's position (current position in league standings)
+        const lastWeekPosition = manager.rank;
+
+        liveStandings.push({
+          managerId: managerId,
+          managerName: manager.player_name,
+          teamName: manager.entry_name,
+          livePoints: livePoints,
+          pointsThisWeek: currentGwPoints,
+          lastWeekPosition: lastWeekPosition,
+          lastWeekPoints: manager.total
+        });
+
+        // Add small delay to avoid overwhelming the API
+        await sleep(100);
+
+      } catch (error) {
+        console.error(`Error fetching data for manager ${managerId}:`, error);
+        // Add manager with fallback data
+        liveStandings.push({
+          managerId: managerId,
+          managerName: manager.player_name,
+          teamName: manager.entry_name,
+          livePoints: manager.total,
+          pointsThisWeek: 0,
+          lastWeekPosition: manager.rank,
+          lastWeekPoints: manager.total
+        });
+      }
+    }
+
+    // Step 4: Sort by live points and calculate position changes
+    console.log('Step 4: Calculating live positions and changes...');
+    liveStandings.sort((a, b) => b.livePoints - a.livePoints);
+
+    // Add current live position and calculate change
+    const results = liveStandings.map((manager, index) => {
+      const currentPosition = index + 1;
+      const positionChange = manager.lastWeekPosition - currentPosition;
+
+      return {
+        ...manager,
+        currentPosition: currentPosition,
+        positionChange: positionChange,
+        changeDirection: positionChange > 0 ? 'up' : positionChange < 0 ? 'down' : 'same'
+      };
+    });
+
+    console.log('--- Request Complete ---');
+    res.status(200).json({
+      gameweek: currentGameweek,
+      results: results
+    });
+
+  } catch (error) {
+    console.error('An unhandled error occurred:', error);
+    res.status(500).json({ error: 'Internal server error. Please try again later.' });
+  }
+};

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,41 @@
 
   <div class="flex flex-col items-center justify-center min-h-screen p-4 space-y-8">
     <h1 class="text-3xl font-bold text-center mb-6 text-green-400">The Robotics Premiership</h1>
+
+    <!-- Live League Table -->
+    <div class="bg-gray-800 p-8 rounded-xl shadow-lg w-full max-w-4xl">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="text-2xl font-semibold text-center text-blue-400">Live League Standings</h2>
+        <button id="refreshButton" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors">
+          Refresh
+        </button>
+      </div>
+
+      <div id="liveStandingsStatus" class="text-center text-sm text-gray-400 mb-4"></div>
+
+      <div id="liveStandingsContainer" class="hidden">
+        <h3 id="liveGameweekTitle" class="text-xl font-semibold mb-4 text-center"></h3>
+        <div class="overflow-x-auto">
+          <table class="min-w-full bg-gray-700 rounded-lg overflow-hidden">
+            <thead>
+              <tr class="bg-gray-600 text-left">
+                <th class="px-3 py-2 text-base font-medium">Pos</th>
+                <th class="px-3 py-2 text-base font-medium">Manager</th>
+                <th class="px-3 py-2 text-base font-medium text-center">Live Pts</th>
+                <th class="px-3 py-2 text-base font-medium text-center">GW Pts</th>
+                <th class="px-3 py-2 text-base font-medium text-center">Change</th>
+              </tr>
+            </thead>
+            <tbody id="liveStandingsTableBody">
+            </tbody>
+          </table>
+        </div>
+        <div class="text-xs text-gray-400 mt-2 text-center">
+          Last updated: <span id="lastUpdated"></span>
+        </div>
+      </div>
+    </div>
+
     <div class="bg-gray-800 p-8 rounded-xl shadow-lg w-full max-w-2xl">
       
       <div id="statusMessage" class="text-center text-sm text-gray-400 mb-4"></div>
@@ -58,6 +93,14 @@
     document.addEventListener('DOMContentLoaded', async () => {
       const leagueId = '870661';
 
+      // Elements for live standings
+      const liveStandingsStatus = document.getElementById('liveStandingsStatus');
+      const liveStandingsContainer = document.getElementById('liveStandingsContainer');
+      const liveStandingsTableBody = document.getElementById('liveStandingsTableBody');
+      const liveGameweekTitle = document.getElementById('liveGameweekTitle');
+      const lastUpdated = document.getElementById('lastUpdated');
+      const refreshButton = document.getElementById('refreshButton');
+
       // Elements for the first table (Auto-Subs)
       const statusMessage = document.getElementById('statusMessage');
       const resultsContainer = document.getElementById('resultsContainer');
@@ -70,11 +113,83 @@
       const transferCostTableBody = document.getElementById('transferCostTableBody');
       const transferCostGameweekTitle = document.getElementById('transferCostGameweekTitle');
 
+      // Function to get position change arrow and color
+      const getPositionChangeDisplay = (positionChange, changeDirection) => {
+        if (changeDirection === 'same') {
+          return '<span class="text-gray-400">-</span>';
+        } else if (changeDirection === 'up') {
+          return `<span class="text-green-400 font-bold">↑${positionChange}</span>`;
+        } else {
+          return `<span class="text-red-400 font-bold">↓${Math.abs(positionChange)}</span>`;
+        }
+      };
+
+      // Function to fetch and display live standings
+      const fetchLiveStandings = async () => {
+        liveStandingsStatus.textContent = 'Fetching live standings...';
+        liveStandingsContainer.classList.add('hidden');
+
+        try {
+          const response = await fetch(`/api/get-live-standings?leagueId=${leagueId}`);
+          const data = await response.json();
+
+          if (response.ok) {
+            liveStandingsStatus.textContent = '';
+            liveGameweekTitle.textContent = `Gameweek ${data.gameweek} - Live Standings`;
+
+            // Clear existing rows
+            liveStandingsTableBody.innerHTML = '';
+
+            if (data.results.length === 0) {
+              liveStandingsTableBody.innerHTML = '<tr><td colspan="5" class="text-center p-4 text-gray-400">No standings data available.</td></tr>';
+            } else {
+              data.results.forEach((manager) => {
+                const row = document.createElement('tr');
+                row.classList.add('border-b', 'border-gray-600', 'hover:bg-gray-600', 'transition-colors');
+
+                const positionChangeHtml = getPositionChangeDisplay(manager.positionChange, manager.changeDirection);
+
+                row.innerHTML = `
+                  <td class="px-3 py-2 font-bold text-lg">${manager.currentPosition}</td>
+                  <td class="px-3 py-2">
+                    <div class="font-semibold">${manager.teamName}</div>
+                    <div class="text-sm text-gray-400">${manager.managerName}</div>
+                  </td>
+                  <td class="px-3 py-2 text-center font-bold text-blue-400">${manager.livePoints}</td>
+                  <td class="px-3 py-2 text-center font-bold text-yellow-400">${manager.pointsThisWeek}</td>
+                  <td class="px-3 py-2 text-center">${positionChangeHtml}</td>
+                `;
+                liveStandingsTableBody.appendChild(row);
+              });
+            }
+
+            // Update last updated time
+            lastUpdated.textContent = new Date().toLocaleTimeString();
+            liveStandingsContainer.classList.remove('hidden');
+
+          } else {
+            liveStandingsStatus.textContent = data.error || 'Failed to fetch live standings.';
+          }
+
+        } catch (error) {
+          console.error('Fetch live standings error:', error);
+          liveStandingsStatus.textContent = 'An unexpected error occurred. Please check your network connection.';
+        }
+      };
+
+      // Refresh button event listener
+      refreshButton.addEventListener('click', fetchLiveStandings);
+
       // Initialize status messages
+      liveStandingsStatus.textContent = 'Fetching live standings...';
       statusMessage.textContent = 'Fetching auto-sub data...';
       transferCostStatus.textContent = 'Fetching transfer cost data...';
       resultsContainer.classList.add('hidden');
       transferCostContainer.classList.add('hidden');
+      liveStandingsContainer.classList.add('hidden');
+
+      // Fetch live standings first
+      await fetchLiveStandings();
 
       // Fetch and populate Auto-Sub data
       try {


### PR DESCRIPTION
- Add new API endpoint /api/get-live-standings.js for fetching live FPL data
- Implement live league table with current positions and gameweek points
- Add position change indicators with green/red arrows
- Include refresh button for manual updates during match days
- Display live points that update during games vs official league table
- Responsive design consistent with existing dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)